### PR TITLE
fix: change emit compressed file and delete original assets order

### DIFF
--- a/__tests__/plugin.spec.ts
+++ b/__tests__/plugin.spec.ts
@@ -200,3 +200,15 @@ test('exclude-assets', async (t) => {
   const compressed = len(r.filter((s) => s.endsWith('.gz')))
   t.is(compressed, 2)
 })
+
+test('aws s3', async (t) => {
+  const id = await mockBuild({ filename: '[path][base]', deleteOriginalAssets: true }, 'dynamic')
+  await sleep(3000)
+  const r = await readAll(path.join(dist, id))
+  const compressed = len(r.filter((s) => s.endsWith('.gz')))
+  t.is(compressed, 0)
+  // eslint-disable-next-line padded-blocks
+  const css = r.filter(v => v.endsWith('.css'))[0]
+  const bf = zlib.unzipSync(fs.readFileSync(css))
+  t.is(bf.toString(), '.pr{padding-right:30px}.pl{padding-left:30px}.mt{margin-top:30px}\n')
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,6 +156,7 @@ function compression<T, A extends Algorithm>(opts: ViteCompressionPluginConfig<T
         const bundle = bundles[file]
         const source = bundle.type === 'asset' ? bundle.source : bundle.code
         const compressed = await transfer(Buffer.from(source), zlib.algorithm, zlib.options)
+        // #issue 30
         if (deleteOriginalAssets) Reflect.deleteProperty(bundles, file)
         const fileName = replaceFileName(file, zlib.filename)
         this.emitFile({ type: 'asset', source: compressed, fileName })
@@ -180,8 +181,10 @@ function compression<T, A extends Algorithm>(opts: ViteCompressionPluginConfig<T
           const buf = await fsp.readFile(f)
           const compressed = await transfer(buf, zlib.algorithm, zlib.options)
           const fileName = replaceFileName(file, zlib.filename)
-          await fsp.writeFile(path.join(dest, fileName), compressed)
-          if (deleteOriginalAssets) await fsp.rm(f, { recursive: true, force: true })
+          // issue #30
+          const outputPath = path.join(dest, fileName)
+          if (deleteOriginalAssets && outputPath !== f) await fsp.rm(f, { recursive: true, force: true })
+          await fsp.writeFile(outputPath, compressed)
         }
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,9 +156,9 @@ function compression<T, A extends Algorithm>(opts: ViteCompressionPluginConfig<T
         const bundle = bundles[file]
         const source = bundle.type === 'asset' ? bundle.source : bundle.code
         const compressed = await transfer(Buffer.from(source), zlib.algorithm, zlib.options)
+        if (deleteOriginalAssets) Reflect.deleteProperty(bundles, file)
         const fileName = replaceFileName(file, zlib.filename)
         this.emitFile({ type: 'asset', source: compressed, fileName })
-        if (deleteOriginalAssets) Reflect.deleteProperty(bundles, file)
         stores.delete(file)
       }
       try {


### PR DESCRIPTION
Sometimes we need use original filename without .gz extension. (ex. [aws s3](https://github.com/webpack-contrib/compression-webpack-plugin/issues/117))
When I tried it by set filename to `[path][base]`, `this.emitFile` dose not overwrite original files.
Therefore I switch order **emit compress file** and **delete original**.