### PR TITLE
refactor: project logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ export default defineConfig({
 | `algorithm`            | `string\| function`                           | `gzip`            | The compression algorithm                                      |
 | `compressionOptions`   | `Record<string,any>`                          | `{}`              | Compression options for `algorithm`(details see `zlib module`) |
 | `deleteOriginalAssets` | `boolean`                                     | `false`           | Whether to delete the original assets or not                   |
-| `skipIfLargerOrEqual`  | `boolean`                                     | `false`            | Whether to skip the compression if the result is larger than or equal to the original file |
+| `skipIfLargerOrEqual`  | `boolean`                                     | `true`            | Whether to skip the compression if the result is larger than or equal to the original file |
 | `filename`             | `string`                                      | `[path][base].gz` | The target asset filename                                      |
 
 ## Q & A

--- a/__tests__/options.spec.ts
+++ b/__tests__/options.spec.ts
@@ -15,6 +15,7 @@ async function mockBuild<T extends Algorithm = never>(
   dir: string,
   single = false
 ) {
+  conf.skipIfLargerOrEqual = conf.skipIfLargerOrEqual ?? false
   const id = getId()
   await build({
     build: {

--- a/__tests__/plugin.spec.ts
+++ b/__tests__/plugin.spec.ts
@@ -6,9 +6,8 @@ import util from 'util'
 import type { ZlibOptions } from 'zlib'
 import test from 'ava'
 import { build } from 'vite'
-import { compression } from '../src'
 import { len, readAll } from '../src/utils'
-import type { Algorithm, ViteCompressionPluginConfig } from '../src'
+import { type Algorithm, type ViteCompressionPluginConfig, compression } from '../src'
 
 const getId = () => Math.random().toString(32).slice(2, 10)
 
@@ -26,7 +25,11 @@ async function mockBuild<T = never, A extends Algorithm = never, K = never, B ex
 ): Promise<string>
 async function mockBuild(config: any = {}, dir = 'normal') {
   const id = getId()
-  const plugins = Array.isArray(config) ? config.map((conf) => compression(conf)) : [compression(config)]
+  const configs = Array.isArray(config) ? config : [config]
+  const plugins = configs.map(conf => {
+    conf.skipIfLargerOrEqual = conf.skipIfLargerOrEqual ?? false
+    return compression(conf)
+  })
   await build({
     root: path.join(__dirname, 'fixtures', dir),
     plugins,

--- a/example/vite.config.js
+++ b/example/vite.config.js
@@ -9,8 +9,7 @@ export default defineConfig({
     cdn({ modules: ['vue', '@fect-ui/vue'] }),
     compression({
       include: [/\.(js)$/, /\.(css)$/],
-      deleteOriginalAssets: true,
-      filename: '[path][base]'
+      deleteOriginalAssets: true
     })
   ]
 })

--- a/example/vite.config.js
+++ b/example/vite.config.js
@@ -9,7 +9,8 @@ export default defineConfig({
     cdn({ modules: ['vue', '@fect-ui/vue'] }),
     compression({
       include: [/\.(js)$/, /\.(css)$/],
-      deleteOriginalAssets: true
+      deleteOriginalAssets: true,
+      filename: '[path][base]'
     })
   ]
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,7 @@ function compression<T extends UserCompressionOptions, A extends Algorithm>(opts
     filename,
     compressionOptions,
     deleteOriginalAssets = false,
-    skipIfLargerOrEqual = false
+    skipIfLargerOrEqual = true
   } = opts
 
   const filter = createFilter(include, exclude)

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,4 +1,5 @@
 import type { BrotliOptions, ZlibOptions } from 'zlib'
+import type { HookHandler, Plugin } from 'vite'
 import type { FilterPattern } from '@rollup/pluginutils'
 
 export type Algorithm = 'gzip' | 'brotliCompress' | 'deflate' | 'deflateRaw'
@@ -58,18 +59,4 @@ export type ViteCompressionPluginConfig<T, A extends Algorithm> =
   | ViteCompressionPluginConfigFunction<T>
   | ViteCompressionPluginConfigAlgorithm<A>
 
-interface BaseCompressMetaInfo {
-  effect: boolean
-}
-
-interface NormalCompressMetaInfo extends BaseCompressMetaInfo {
-  effect: false
-}
-
-interface DyanmiCompressMetaInfo extends BaseCompressMetaInfo {
-  effect: true
-  file: string[]
-  dest: string[]
-}
-
-export type CompressMetaInfo = NormalCompressMetaInfo | DyanmiCompressMetaInfo
+export type GenerateBundle = HookHandler<Plugin['generateBundle']>


### PR DESCRIPTION
# CheckList

- [x] Abandon the concept of file side effects.
- [x] Clean code.
- [x] Reduce bundle size.
- [x] `skipIfLargerOrEqual` is true by default.

# Details

This pull request change the plugin execution logic. Now compress file will be bind after vite's internal `build-import-analysis` plugin. So we won't need more `fs` io. Maybe this PR will be useful #18 