### PR TITLE
Fix README.md markdown error

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ export default defineConfig({
 
 | params                 | type                                          | default                                                   | description                                                                                |
 | ---------------------- | --------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| `include`              | `string \| RegExp \| Array<string \| RegExp>` | `/\.(html\|xml\|css\|json\|js\|mjs\|svg|yaml|yml|toml)$/` | Include all assets matching any of these conditions.                                       |
+| `include`              | `string \| RegExp \| Array<string \| RegExp>` | `/\.(html\|xml\|css\|json\|js\|mjs\|svg\|yaml\|yml\|toml)$/` | Include all assets matching any of these conditions.                                       |
 | `exclude`              | `string \| RegExp \| Array<string \| RegExp>` | `-`                                                       | Exclude all assets matching any of these conditions.                                       |
 | `threshold`            | `number`                                      | `0`                                                       | Only assets bigger than this size are processed (in bytes)                                 |
 | `algorithm`            | `string\| function`                           | `gzip`                                                    | The compression algorithm                                                                  |


### PR DESCRIPTION
Escaped the pipe character in the include's default regexp