### PR TITLE
zstd level 22

### DIFF
--- a/src/compress.ts
+++ b/src/compress.ts
@@ -72,8 +72,11 @@ export const defaultCompressionOptions: {
   deflateRaw: {
     level: zlib.constants.Z_BEST_COMPRESSION
   },
-  // I don't know what the best default options for zstd are, so using an empty object
-  zstandard: {}
+  zstandard: {
+    params: {
+      [zlib.constants.ZSTD_c_compressionLevel]: 22
+    }
+  }
 }
 
 interface TarballOptions {


### PR DESCRIPTION
References:
https://nodejs.org/docs/latest-v25.x/api/zlib.html#zstd-constants
https://docs.aws.amazon.com/athena/latest/ug/compression-support-zstd-levels.html